### PR TITLE
Update detekt-hint.yaml

### DIFF
--- a/.github/workflows/detekt-hint.yaml
+++ b/.github/workflows/detekt-hint.yaml
@@ -23,6 +23,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run detekt hint
-        uses: Mkohm/detekt-hint-docker-action@v1.4
+        uses: Mkohm/detekt-hint-docker-action@v1.5
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR will make detekt-hint not fail the build, but add comments if danger is able to find the commits. This is because of https://github.com/danger/danger/issues/1103.